### PR TITLE
コメント一覧の表示位置を切り替える機能を追加

### DIFF
--- a/comment-viewer.css
+++ b/comment-viewer.css
@@ -1,3 +1,17 @@
+#comment-panel {
+  width: 100%;
+  height: fit-content;
+}
+
+#position-select {
+  outline: none;
+  border: solid 1px #eee;
+}
+
+.comment-toolbar {
+  margin: 10px 0;
+}
+
 .comment-list {
   width: 100%;
   height: 120px;

--- a/comment-viewer.css
+++ b/comment-viewer.css
@@ -28,7 +28,7 @@
   padding: 5px;
   box-sizing: border-box;
   background-color: #fff;
-  border: solid 1px #eee;
+  border-bottom: solid 1px #eee;
 }
 
 .comment::before {

--- a/comment-viewer.js
+++ b/comment-viewer.js
@@ -1,11 +1,37 @@
 'use strict';
 
 const videoPlayer = document.querySelector('[aria-label="動画プレイヤー"]');
+const asideElement = document.querySelector('aside');
 const timeElement = document.querySelector('time');
 
-const commentList = document.createElement('ul');
-commentList.classList.add('comment-list');
-videoPlayer.parentElement.parentElement.appendChild(commentList);
+// デフォルトでは動画プレイヤーの下に配置する
+videoPlayer.parentElement.parentElement.insertAdjacentHTML('beforeend', `
+  <div id="comment-panel">
+    <ul id="comment-list" class="comment-list"></ul>
+    <div class="comment-toolbar">
+      <label for="position-select">表示位置</label>
+      <select id="position-select">
+        <option value="top-right">右上</option>
+        <option value="bottom-left" selected>左下</option>
+      </select>
+    </div>
+  </div>
+`);
+
+const commentPanel = document.querySelector('#comment-panel');
+const commentList = commentPanel.querySelector('#comment-list');
+const positionSelect = commentPanel.querySelector('#position-select');
+
+// 表示位置の切り替え
+positionSelect.addEventListener('change', (event) => {
+  const position = event.target.value;
+
+  if (position === 'top-right') asideElement.insertAdjacentElement('afterbegin', commentPanel);
+  else if (position === 'bottom-left') videoPlayer.parentElement.parentElement.insertAdjacentElement('beforeend', commentPanel);
+
+  commentList.scrollTop = commentList.scrollHeight;
+  commentPanel.scrollIntoView({ behavior: 'smooth', block: 'center' });
+});
 
 // ---------- コメントを取得して表示する ----------
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "N予備コメビュ",
-  "version": "2.0",
+  "version": "2.1",
   "description": "N予備校の生放送授業において、コメント一覧を表示するChrome拡張 (ISC License)",
   "permissions": [
     "scripting",


### PR DESCRIPTION
コメント一覧の表示位置を左下と右上に切り替えられるようにしました。
@sifue ご確認のほどよろしくお願いいたします。

こちらは授業のスクリーンショットです。
[screenshots.zip](https://github.com/sifue/nyobi-commentviewer/files/12228755/screenshots.zip)
