### PR TITLE
余白を調整

### DIFF
--- a/comment-viewer.css
+++ b/comment-viewer.css
@@ -25,7 +25,7 @@
 
 .comment {
   margin: 0;
-  padding: 5px;
+  padding: 12px;
   box-sizing: border-box;
   background-color: #fff;
   border-bottom: solid 1px #eee;

--- a/comment-viewer.css
+++ b/comment-viewer.css
@@ -14,13 +14,20 @@
 
 .comment-list {
   width: 100%;
-  height: 120px;
   list-style: none;
   overflow-y: scroll;
   box-sizing: border-box;
   background-color: #fff;
   border: solid 1px #eee;
   resize: vertical;
+}
+
+.comment-list[data-position="bottom-left"] {
+  height: 120px;
+}
+
+.comment-list[data-position="top-right"] {
+  height: 350px;
 }
 
 .comment {

--- a/comment-viewer.js
+++ b/comment-viewer.js
@@ -22,12 +22,16 @@ const commentPanel = document.querySelector('#comment-panel');
 const commentList = commentPanel.querySelector('#comment-list');
 const positionSelect = commentPanel.querySelector('#position-select');
 
+commentList.dataset.position = 'bottom-left';
+
 // 表示位置の切り替え
 positionSelect.addEventListener('change', (event) => {
   const position = event.target.value;
 
-  if (position === 'top-right') asideElement.insertAdjacentElement('afterbegin', commentPanel);
+  if (position === 'top-right') {asideElement.insertAdjacentElement('afterbegin', commentPanel);}
   else if (position === 'bottom-left') videoPlayer.parentElement.parentElement.insertAdjacentElement('beforeend', commentPanel);
+
+  commentList.dataset.position = position;
 
   commentList.scrollTop = commentList.scrollHeight;
   commentPanel.scrollIntoView({ behavior: 'smooth', block: 'center' });


### PR DESCRIPTION
#7 をバージョンアップに対応させました。
（Gitに不慣れなものでして...ミスがあったらすみません）

---

余白が狭くコメントが見づらいと感じたため、
commentクラスのpaddingを5px => 12px に変更しました。

また、それに伴い、右側に表示したときにコメントエリアが狭いと感じるようになったため、
comment-listにdata-position属性を追加し、
その値を元にcomment-listの高さ(height)をCSSで変更するようにしました。

<img width="700" alt="参考画像" src="https://github.com/sifue/nyobi-commentviewer/assets/145516449/10f5a688-e682-4e79-87a4-4e8ad3f3531e">